### PR TITLE
Array 関連のテンプレートパラメータ制約の修正

### DIFF
--- a/Siv3D/include/Siv3D/Array.hpp
+++ b/Siv3D/include/Siv3D/Array.hpp
@@ -768,7 +768,7 @@ namespace s3d
 		/// @return 全ての要素が条件を満たすか、配列が空の場合 true, それ以外の場合は false
 		template <class Fty = decltype(Identity)>
 		[[nodiscard]]
-		constexpr bool all(Fty f = Identity) const requires std::predicate<Fty, value_type>;
+		constexpr bool all(Fty f = Identity) const requires std::predicate<Fty, const value_type&>;
 
 		////////////////////////////////////////////////////////////////
 		//
@@ -782,7 +782,7 @@ namespace s3d
 		/// @return 条件を満たす要素が 1 つでもあれば true, それ以外の場合は false
 		template <class Fty = decltype(Identity)>
 		[[nodiscard]]
-		constexpr bool any(Fty f = Identity) const requires std::predicate<Fty, value_type>;
+		constexpr bool any(Fty f = Identity) const requires std::predicate<Fty, const value_type&>;
 
 		////////////////////////////////////////////////////////////////
 		//

--- a/Siv3D/include/Siv3D/Array.hpp
+++ b/Siv3D/include/Siv3D/Array.hpp
@@ -20,12 +20,18 @@
 namespace s3d
 {
 	template <class Type, class Allocator>
-	class Array;	
+	class Array;
 
 	template <class Type>
-	concept HasAsArray = requires(Type t)
+	concept ArrayLike = requires(Type&& t)
 	{
-		{ t.asArray() } -> std::convertible_to<Array<typename Type::value_type, std::allocator<typename Type::value_type>>>;
+		Array<typename std::remove_cvref_t<Type>::value_type, typename std::remove_cvref_t<Type>::allocator_type>{ std::forward<Type>(t) };
+	};
+
+	template <class Type>
+	concept HasAsArray = requires(Type&& t)
+	{
+		{ std::forward<Type>(t).asArray() } -> ArrayLike;
 	};
 
 	////////////////////////////////////////////////////////////////

--- a/Siv3D/include/Siv3D/Array.hpp
+++ b/Siv3D/include/Siv3D/Array.hpp
@@ -197,7 +197,7 @@ namespace s3d
 		/// @tparam Fty ジェネレータ関数の型
 		/// @param size 作成する配列の要素数
 		/// @param generator ジェネレータ関数
-		template <class Fty> requires (std::invocable<Fty> && std::same_as<std::invoke_result_t<Fty>, Type>)
+		template <class Fty> requires (std::invocable<Fty> && std::convertible_to<std::invoke_result_t<Fty>, Type>)
 		[[nodiscard]]
 		Array(size_type size, Arg::generator_<Fty> generator);
 
@@ -1448,7 +1448,7 @@ namespace s3d
 		/// @param size 
 		/// @param generator 
 		/// @return 
-		template <class Fty> requires (std::invocable<Fty>&& std::same_as<std::invoke_result_t<Fty>, Type>)
+		template <class Fty> requires (std::invocable<Fty>&& std::convertible_to<std::invoke_result_t<Fty>, Type>)
 		[[nodiscard]]
 		static Array Generate(size_type size, Fty generator);
 

--- a/Siv3D/include/Siv3D/detail/Array.ipp
+++ b/Siv3D/include/Siv3D/detail/Array.ipp
@@ -82,7 +82,7 @@ namespace s3d
 # endif
 
 	template <class Type, class Allocator>
-	template <class Fty> requires (std::invocable<Fty> && std::same_as<std::invoke_result_t<Fty>, Type>)
+	template <class Fty> requires (std::invocable<Fty> && std::convertible_to<std::invoke_result_t<Fty>, Type>)
 	Array<Type, Allocator>::Array(const size_type size, Arg::generator_<Fty> generator)
 		: Array(Generate<Fty>(size, *generator)) {}
 
@@ -849,7 +849,7 @@ namespace s3d
 
 
 	template <class Type, class Allocator>
-	template <class Fty>  requires (std::invocable<Fty>&& std::same_as<std::invoke_result_t<Fty>, Type>)
+	template <class Fty>  requires (std::invocable<Fty>&& std::convertible_to<std::invoke_result_t<Fty>, Type>)
 	Array<Type, Allocator> Array<Type, Allocator>::Generate(const size_type size, Fty generator)
 	{
 		Array new_array(Arg::reserve = size);

--- a/Siv3D/include/Siv3D/detail/Array.ipp
+++ b/Siv3D/include/Siv3D/detail/Array.ipp
@@ -777,7 +777,7 @@ namespace s3d
 
 	template <class Type, class Allocator>
 	template <class Fty>
-	constexpr bool Array<Type, Allocator>::all(Fty f) const requires std::predicate<Fty, value_type>
+	constexpr bool Array<Type, Allocator>::all(Fty f) const requires std::predicate<Fty, const value_type&>
 	{
 		return std::all_of(m_container.begin(), m_container.end(), f);
 	}
@@ -790,7 +790,7 @@ namespace s3d
 
 	template <class Type, class Allocator>
 	template <class Fty>
-	constexpr bool Array<Type, Allocator>::any(Fty f) const requires std::predicate<Fty, value_type>
+	constexpr bool Array<Type, Allocator>::any(Fty f) const requires std::predicate<Fty, const value_type&>
 	{
 		return std::any_of(m_container.begin(), m_container.end(), f);
 	}


### PR DESCRIPTION
#6 の PR です。

- `value_type` を持たないクラスもコンセプト `HasArray` を満たすようになります
- `Array` に明示的に変換可能なことを示すコンセプト `ArrayLike` が追加されます
- ジェネレータを使って `Array` を作るとき、ジェネレータの戻り値が要素の型と**完全に一致**する必要がなくなり、**変換可能**であればよくなります
- `Array::all()` や `Array::any()` が右辺値参照を受け取る関数を受け取るようなオーバーロードが、テンプレートパラメータ制約によってはじかれるようになります

```c++
# include <Siv3D.hpp>

struct Test
{
    Array<int32> asArray() &&
    {
        return {};
    }
};

void Main()
{
    // Array のコンストラクタが .asArray() を使うのに value_type が不要になる
    // また、右辺値修飾のついた .asArray() も正しく呼べるようになる
    const Array a(Test{});

    // Array<int64> を作るために int や const int64& などを返すジェネレータが使えるようになる
    const Array<int64> b(10, Arg::generator = [x = 0]() mutable { return x++; });

    // 右辺値参照を引数に取るような関数がテンプレートパラメータ制約ではじかれるようになる
    // b.all([](int32&& x) { return x == 0; });  // error
}
```
