### PR TITLE
ScopeExit に関するいくつかの修正

### DIFF
--- a/Siv3D/include/Siv3D/ScopeExit.hpp
+++ b/Siv3D/include/Siv3D/ScopeExit.hpp
@@ -45,6 +45,7 @@ namespace s3d
 			|| std::is_nothrow_copy_constructible_v<ExitFunction>);
 
 		template <class Fty>
+			requires (not std::same_as<std::remove_cvref_t<Fty>, ScopeExit>)
 		[[nodiscard]]
 		constexpr ScopeExit(Fty&& exitFunction) noexcept(std::is_nothrow_constructible_v<ExitFunction, Fty>
 			|| std::is_nothrow_constructible_v<ExitFunction, Fty&>);

--- a/Siv3D/include/Siv3D/ScopeExit.hpp
+++ b/Siv3D/include/Siv3D/ScopeExit.hpp
@@ -17,6 +17,12 @@
 
 namespace s3d
 {
+	namespace detail
+	{
+		template <class T>
+		concept ExitFunction = std::invocable<std::add_lvalue_reference_t<T>> && (not std::is_rvalue_reference_v<T>);
+	}
+
 	////////////////////////////////////////////////////////////////
 	//
 	//	ScopeExit
@@ -25,7 +31,7 @@ namespace s3d
 
 	/// @brief スコープを抜けるときに指定した関数を実行するオブジェクト | An object that executes a specified function when it leaves the scope
 	/// @tparam ExitFunction 実行する関数の型 | The type of the function to execute
-	template <std::invocable ExitFunction>
+	template <detail::ExitFunction ExitFunction>
 	class ScopeExit final
 	{
 	public:
@@ -43,7 +49,7 @@ namespace s3d
 		constexpr ScopeExit(Fty&& exitFunction) noexcept(std::is_nothrow_constructible_v<ExitFunction, Fty>
 			|| std::is_nothrow_constructible_v<ExitFunction, Fty&>);
 
-		constexpr ~ScopeExit() noexcept(std::is_nothrow_invocable_v<ExitFunction>
+		constexpr ~ScopeExit() noexcept(std::is_nothrow_invocable_v<ExitFunction&>
 			&& std::is_nothrow_destructible_v<ExitFunction>);
 
 		/// @brief ScopeExit を非アクティブにします。 | Deactivates the ScopeExit.
@@ -56,7 +62,7 @@ namespace s3d
 		bool m_active = true;
 	};
 
-	template <std::invocable ExitFunction>
+	template <detail::ExitFunction ExitFunction>
 	ScopeExit(ExitFunction) -> ScopeExit<ExitFunction>;
 }
 

--- a/Siv3D/include/Siv3D/ScopeExit.hpp
+++ b/Siv3D/include/Siv3D/ScopeExit.hpp
@@ -41,14 +41,21 @@ namespace s3d
 		ScopeExit& operator =(const ScopeExit&) = delete;
 
 		[[nodiscard]]
-		constexpr ScopeExit(ScopeExit&& other) noexcept(std::is_nothrow_move_constructible_v<ExitFunction>
-			|| std::is_nothrow_copy_constructible_v<ExitFunction>);
+		constexpr ScopeExit(ScopeExit&& other) noexcept(std::is_nothrow_copy_constructible_v<ExitFunction>);
+
+		[[nodiscard]]
+		constexpr ScopeExit(ScopeExit&& other) noexcept
+			requires std::is_nothrow_move_constructible_v<ExitFunction>;
 
 		template <class Fty>
 			requires (not std::same_as<std::remove_cvref_t<Fty>, ScopeExit>)
 		[[nodiscard]]
-		constexpr ScopeExit(Fty&& exitFunction) noexcept(std::is_nothrow_constructible_v<ExitFunction, Fty>
-			|| std::is_nothrow_constructible_v<ExitFunction, Fty&>);
+		constexpr ScopeExit(Fty&& exitFunction) noexcept(std::is_nothrow_constructible_v<ExitFunction, Fty&>);
+
+		template <class Fty>
+			requires ((not std::same_as<std::remove_cvref_t<Fty>, ScopeExit>) && (not std::is_lvalue_reference_v<Fty>) && std::is_nothrow_constructible_v<ExitFunction, Fty>)
+		[[nodiscard]]
+		constexpr ScopeExit(Fty&& exitFunction) noexcept;
 
 		constexpr ~ScopeExit() noexcept(std::is_nothrow_invocable_v<ExitFunction&>
 			&& std::is_nothrow_destructible_v<ExitFunction>);

--- a/Siv3D/include/Siv3D/detail/ScopeExit.ipp
+++ b/Siv3D/include/Siv3D/detail/ScopeExit.ipp
@@ -27,6 +27,7 @@ namespace s3d
 	
 	template <detail::ExitFunction ExitFunction>
 	template <class Fty>
+		requires (not std::same_as<std::remove_cvref_t<Fty>, ScopeExit<ExitFunction>>)
 	constexpr ScopeExit<ExitFunction>::ScopeExit(Fty&& exitFunction) noexcept(std::is_nothrow_constructible_v<ExitFunction, Fty>
 																				|| std::is_nothrow_constructible_v<ExitFunction, Fty&>)
 		: m_exitFunction{ std::forward<Fty>(exitFunction) } {}

--- a/Siv3D/include/Siv3D/detail/ScopeExit.ipp
+++ b/Siv3D/include/Siv3D/detail/ScopeExit.ipp
@@ -29,7 +29,7 @@ namespace s3d
 	template <class Fty>
 	constexpr ScopeExit<ExitFunction>::ScopeExit(Fty&& exitFunction) noexcept(std::is_nothrow_constructible_v<ExitFunction, Fty>
 																				|| std::is_nothrow_constructible_v<ExitFunction, Fty&>)
-		: m_exitFunction{ std::forward<ExitFunction>(exitFunction) } {}
+		: m_exitFunction{ std::forward<Fty>(exitFunction) } {}
 		
 	////////////////////////////////////////////////////////////////
 	//

--- a/Siv3D/include/Siv3D/detail/ScopeExit.ipp
+++ b/Siv3D/include/Siv3D/detail/ScopeExit.ipp
@@ -19,13 +19,13 @@ namespace s3d
 	//
 	////////////////////////////////////////////////////////////////
 
-	template <std::invocable ExitFunction>
+	template <detail::ExitFunction ExitFunction>
 	constexpr ScopeExit<ExitFunction>::ScopeExit(ScopeExit&& other) noexcept(std::is_nothrow_move_constructible_v<ExitFunction>
 																				|| std::is_nothrow_copy_constructible_v<ExitFunction>)
 		: m_exitFunction{ std::move(other.m_exitFunction) }
 		, m_active{ std::exchange(other.m_active, false) } {}
 	
-	template <std::invocable ExitFunction>
+	template <detail::ExitFunction ExitFunction>
 	template <class Fty>
 	constexpr ScopeExit<ExitFunction>::ScopeExit(Fty&& exitFunction) noexcept(std::is_nothrow_constructible_v<ExitFunction, Fty>
 																				|| std::is_nothrow_constructible_v<ExitFunction, Fty&>)
@@ -37,8 +37,8 @@ namespace s3d
 	//
 	////////////////////////////////////////////////////////////////
 
-	template <std::invocable ExitFunction>
-	constexpr ScopeExit<ExitFunction>::~ScopeExit() noexcept(std::is_nothrow_invocable_v<ExitFunction>
+	template <detail::ExitFunction ExitFunction>
+	constexpr ScopeExit<ExitFunction>::~ScopeExit() noexcept(std::is_nothrow_invocable_v<ExitFunction&>
 		&& std::is_nothrow_destructible_v<ExitFunction>)
 	{
 		if (m_active)
@@ -53,7 +53,7 @@ namespace s3d
 	//
 	////////////////////////////////////////////////////////////////
 
-	template <std::invocable ExitFunction>
+	template <detail::ExitFunction ExitFunction>
 	constexpr void ScopeExit<ExitFunction>::release() noexcept
 	{
 		m_active = false;


### PR DESCRIPTION
変更ごとに PR を分けようと思いましたが、変更箇所が重なっているなどの理由で厳しかったので、1つにまとめました。
不要な変更があれば revert します。

以下ではコミットごとにその内容を説明します。



### [ScopeExit のテンプレートパラメータ制約の修正](https://github.com/Siv3D/siv8/pull/8/commits/ae3b7d5809a5f04fe3556ddfa0845d67292ce1e5)

`ScopeExit` のテンプレート引数 `ExitFunction` には `std::invocable<ExitFunction>` を要求していますが、 `ExitFunction` が満たすべき条件は**左辺値から**関数呼び出し可能であることなので、 `std::invocable<ExitFunction>` より `std::invocable<std::add_lvalue_reference_t<ExitFunction>>` が適切です。
また、 `ExitFunction` が右辺値参照であるとき、デストラクタで未定義動作を起こしうるので、 `ExitFunction` が右辺値参照出ないことも要件に加えたほうが安全です。

これらの要件をまとめたコンセプトを `s3d::detail` 名前空間に置きました。

```cpp
# include <Siv3D.hpp>

struct Test1
{
	void operator ()() && {}
};

struct Test2
{
	void operator ()() {}
};

void Main()
{
	// 変更前 → 変更後

	const ScopeExit test1{ Test1{} };  // std::invoke(m_exitFunction) に失敗 → テンプレート引数推論に失敗

	const ScopeExit<Test2&&> test2{ Test2{} };  // デストラクタで未定義動作 → コンパイルエラー
}
```



### [std::forward() のテンプレート引数の修正](https://github.com/Siv3D/siv8/pull/8/commits/9eac3e20db43163e8c0ae1e2e6cf4e726701b70d)

`std::forward()` のテンプレート引数と引数が対応していなかったので、修正しました。



### [コピーコンストラクタの代わりに万能参照を取るコンストラクタが選ばれないよう修正](https://github.com/Siv3D/siv8/pull/8/commits/d1b570829b446c705efebf55fede641c6503aef1)

コンストラクタに `ScopeExit<ExitFunction>&` を渡したとき、選ばれるオーバーロードは `ScopeExit(const ScopeExit<ExitFunction>&)` ではなく `ScopeExit(Fty&&) [with Fty = ScopeExit<ExitFunction>&]` です。
そのため、エラーメッセージが「削除されたコピーコンストラクタを使用した。」ではなく「 `ScopeExit::ScopeExit(Fty&&)` の初期化子で `ScopeExit<ExitFunction>` を `ExitFunction` に変換できなかった。」になり、直感的でないです。

オーバーロード `ScopeExit::ScopeExit(Fty&&)` に要件 `not std::same_as<std::remove_cvref_t<Fty>, ScopeExit>` を加えることで解決しました。

このケースに限らず、ユニバーサル参照を受け取るコンストラクタには、標準ライブラリなどに倣って自身のクラスを受け取らないことを制約に加えるべきです。

```cpp
# include <Siv3D.hpp>

void Main()
{
	const ScopeExit se1 = [] {};
	ScopeExit se2 = [] {};

	ScopeExit se3 = se1;  // コピーコンストラクタが削除されているのでエラー
	ScopeExit se4 = se2;  // ScopeExit<ExitFunction> から ExitFunction へ変換できないのでエラー
	                      // → コピーコンストラクタが削除されているのでエラー
}
```



### [例外指定と呼び出すコンストラクタが正しく対応するよう修正](https://github.com/Siv3D/siv8/pull/8/commits/5adac3fe8cf7c3b2d83605502d36d7c63cc052bc)

`ScopeExit` のムーブコンストラクタの例外指定は `noexcept(std::is_nothrow_move_constructible_v<ExitFunction> || std::is_nothrow_copy_constructible_v<ExitFunction>)` のようになっているので、 `ExitFunction` が noexcept にムーブ構築可能でなく、 noexcept にコピー構築可能である場合、ムーブコンストラクタは noexcept 指定されます。
しかし、ムーブコンストラクタは常に `m_exitFunction` をムーブするように実装されています。
ここで、 `m_exitFunction` をムーブするときに例外が搬出される可能性がありますが、ムーブコンストラクタは noexcept 指定されているので、そのときは `std::terminate()` が呼び出されます。
このように、例外指定に関わったコンストラクタと呼び出されるコンストラクタが異なることから問題が発生します。
また、ユニバーサル参照を受け取るコンストラクタでも同様の問題があります。

これを解決するため、 `m_exitFunction` をコピー構築するようなコンストラクタをオーバーロードを追加しました。
`ExitFunction` のムーブコンストラクタが例外を搬出しうるときは、コピーコンストラクタが選択されます。
これは、標準ライブラリに倣った動作です。

この変更の影響で、コピーコンストラクタを持たず、例外を搬出しうるムーブコンストラクタを持つクラスが適合しなくなります。

```cpp
# include <Siv3D.hpp>

struct Test
{
	Test() noexcept = default;
	Test(const Test&) noexcept = default;

	Test(Test&&)
	{
		throw Error{ U"moved" };
	}

	void operator ()() const {}
};


void Main()
{
	const ScopeExit test{ Test{} };
	// 変更前：コピーコンストラクタが noexcept なのでコンストラクタが noexcept 指定される。
	//         しかし、完全転送の際にムーブコンストラクタが呼び出され、例外が投げられる。
	//         結果、 std::terminate() が呼び出される。
	// 変更後：ムーブコンストラクタが noexcept でないので、コピーコンストラクタが呼び出される。
}
```
