### PR TITLE
UniqueResource のコンストラクタを修正

### DIFF
--- a/Siv3D/include/Siv3D/UniqueResource.hpp
+++ b/Siv3D/include/Siv3D/UniqueResource.hpp
@@ -34,8 +34,9 @@ namespace s3d
 		[[nodiscard]]
 		UniqueResource() = default;
 
+		template <class R, class D>
 		[[nodiscard]]
-		explicit UniqueResource(Resource&& resource, Deleter&& deleter) noexcept;
+		explicit UniqueResource(R&& resource, D&& deleter) noexcept;
 
 		[[nodiscard]]
 		UniqueResource(UniqueResource&& other) noexcept;

--- a/Siv3D/include/Siv3D/detail/UniqueResource.ipp
+++ b/Siv3D/include/Siv3D/detail/UniqueResource.ipp
@@ -20,9 +20,10 @@ namespace s3d
 	////////////////////////////////////////////////////////////////
 
 	template <class Resource, class Deleter>
-	inline UniqueResource<Resource, Deleter>::UniqueResource(Resource&& resource, Deleter&& deleter) noexcept
-		: m_resource{ std::forward<Resource>(resource) }
-		, m_deleter{ std::forward<Deleter>(deleter) } {}
+	template <class R, class D>
+	inline UniqueResource<Resource, Deleter>::UniqueResource(R&& resource, D&& deleter) noexcept
+		: m_resource{ std::forward<R>(resource) }
+		, m_deleter{ std::forward<D>(deleter) } {}
 
 	template <class Resource, class Deleter>
 	inline UniqueResource<Resource, Deleter>::UniqueResource(UniqueResource&& other) noexcept


### PR DESCRIPTION
コンストラクタの引数を完全転送するには、コンストラクタがテンプレート引数を取る必要があります。
`Resource&&` および `Deleter&&` はユニバーサル参照ではなく、常に右辺値参照です。

```cpp
# include <Siv3D.hpp>

void Main()
{
	const auto p = new int32{ 42 };
	UniqueResource resource{ p, std::default_delete<int32>{} };
	// 変更前：エラー！ p を int32*&& で受け取れない [Resource = int32*]
	// 変更後： p はコピーされる [Resource = int32*, R = int32 *const &]
}
```
