### PR TITLE
ScopeExit の制約や例外指定に関する修正

### DIFF
--- a/Siv3D/include/Siv3D/ScopeExit.hpp
+++ b/Siv3D/include/Siv3D/ScopeExit.hpp
@@ -46,14 +46,21 @@ namespace s3d
 		ScopeExit& operator =(const ScopeExit&) = delete;
 
 		[[nodiscard]]
-		constexpr ScopeExit(ScopeExit&& other) noexcept(std::is_nothrow_move_constructible_v<ExitFunction>
-			|| std::is_nothrow_copy_constructible_v<ExitFunction>);
+		constexpr ScopeExit(ScopeExit&& other) noexcept(std::is_nothrow_copy_constructible_v<ExitFunction>);
+
+		[[nodiscard]]
+		constexpr ScopeExit(ScopeExit&& other) noexcept
+			requires std::is_nothrow_move_constructible_v<ExitFunction>;
 
 		template <class Fty>
 			requires detail::not_same_as<std::remove_cvref_t<Fty>, ScopeExit<ExitFunction>>
 		[[nodiscard]]
-		constexpr ScopeExit(Fty&& exitFunction) noexcept(std::is_nothrow_constructible_v<ExitFunction, Fty>
-			|| std::is_nothrow_constructible_v<ExitFunction, Fty&>);
+		constexpr ScopeExit(Fty&& exitFunction) noexcept(std::is_nothrow_constructible_v<ExitFunction, Fty&>);
+
+		template <class Fty>
+			requires (detail::not_same_as<std::remove_cvref_t<Fty>, ScopeExit<ExitFunction>> && (not std::is_lvalue_reference_v<Fty>) && std::is_nothrow_constructible_v<ExitFunction, Fty>)
+		[[nodiscard]]
+		constexpr ScopeExit(Fty&& exitFunction) noexcept;
 
 		constexpr ~ScopeExit() noexcept(std::is_nothrow_invocable_v<ExitFunction&>
 			&& std::is_nothrow_destructible_v<ExitFunction>);

--- a/Siv3D/include/Siv3D/ScopeExit.hpp
+++ b/Siv3D/include/Siv3D/ScopeExit.hpp
@@ -17,6 +17,12 @@
 
 namespace s3d
 {
+	namespace detail
+	{
+		template <class T>
+		concept ExitFunction = std::invocable<std::add_lvalue_reference_t<T>> && (not std::is_rvalue_reference_v<T>);
+	}
+
 	////////////////////////////////////////////////////////////////
 	//
 	//	ScopeExit
@@ -25,7 +31,7 @@ namespace s3d
 
 	/// @brief スコープを抜けるときに指定した関数を実行するオブジェクト | An object that executes a specified function when it leaves the scope
 	/// @tparam ExitFunction 実行する関数の型 | The type of the function to execute
-	template <std::invocable ExitFunction>
+	template <detail::ExitFunction ExitFunction>
 	class ScopeExit final
 	{
 	public:
@@ -43,7 +49,7 @@ namespace s3d
 		constexpr ScopeExit(Fty&& exitFunction) noexcept(std::is_nothrow_constructible_v<ExitFunction, Fty>
 			|| std::is_nothrow_constructible_v<ExitFunction, Fty&>);
 
-		constexpr ~ScopeExit() noexcept(std::is_nothrow_invocable_v<ExitFunction>
+		constexpr ~ScopeExit() noexcept(std::is_nothrow_invocable_v<ExitFunction&>
 			&& std::is_nothrow_destructible_v<ExitFunction>);
 
 		/// @brief ScopeExit を非アクティブにします。 | Deactivates the ScopeExit.
@@ -56,7 +62,7 @@ namespace s3d
 		bool m_active = true;
 	};
 
-	template <std::invocable ExitFunction>
+	template <detail::ExitFunction ExitFunction>
 	ScopeExit(ExitFunction) -> ScopeExit<ExitFunction>;
 }
 

--- a/Siv3D/include/Siv3D/ScopeExit.hpp
+++ b/Siv3D/include/Siv3D/ScopeExit.hpp
@@ -21,6 +21,11 @@ namespace s3d
 	{
 		template <class T>
 		concept ExitFunction = std::invocable<std::add_lvalue_reference_t<T>> && (not std::is_rvalue_reference_v<T>);
+
+		template <class T, class U>
+		concept not_same_as_impl = (not std::is_same_v<T, U>);
+		template <class T, class U>
+		concept not_same_as = (not_same_as_impl<T, U> && not_same_as_impl<U, T>);
 	}
 
 	////////////////////////////////////////////////////////////////
@@ -45,6 +50,7 @@ namespace s3d
 			|| std::is_nothrow_copy_constructible_v<ExitFunction>);
 
 		template <class Fty>
+			requires detail::not_same_as<std::remove_cvref_t<Fty>, ScopeExit<ExitFunction>>
 		[[nodiscard]]
 		constexpr ScopeExit(Fty&& exitFunction) noexcept(std::is_nothrow_constructible_v<ExitFunction, Fty>
 			|| std::is_nothrow_constructible_v<ExitFunction, Fty&>);

--- a/Siv3D/include/Siv3D/ScopeExit.hpp
+++ b/Siv3D/include/Siv3D/ScopeExit.hpp
@@ -53,14 +53,14 @@ namespace s3d
 			requires std::is_nothrow_move_constructible_v<ExitFunction>;
 
 		template <class Fty>
-			requires detail::not_same_as<std::remove_cvref_t<Fty>, ScopeExit<ExitFunction>>
 		[[nodiscard]]
-		constexpr ScopeExit(Fty&& exitFunction) noexcept(std::is_nothrow_constructible_v<ExitFunction, Fty&>);
+		constexpr ScopeExit(Fty&& exitFunction) noexcept(std::is_nothrow_constructible_v<ExitFunction, Fty&>)
+			requires detail::not_same_as<std::remove_cvref_t<Fty>, ScopeExit>;
 
 		template <class Fty>
-			requires (detail::not_same_as<std::remove_cvref_t<Fty>, ScopeExit<ExitFunction>> && (not std::is_lvalue_reference_v<Fty>) && std::is_nothrow_constructible_v<ExitFunction, Fty>)
 		[[nodiscard]]
-		constexpr ScopeExit(Fty&& exitFunction) noexcept;
+		constexpr ScopeExit(Fty&& exitFunction) noexcept
+			requires (detail::not_same_as<std::remove_cvref_t<Fty>, ScopeExit> && (not std::is_lvalue_reference_v<Fty>) && std::is_nothrow_constructible_v<ExitFunction, Fty>);
 
 		constexpr ~ScopeExit() noexcept(std::is_nothrow_invocable_v<ExitFunction&>
 			&& std::is_nothrow_destructible_v<ExitFunction>);

--- a/Siv3D/include/Siv3D/detail/ScopeExit.ipp
+++ b/Siv3D/include/Siv3D/detail/ScopeExit.ipp
@@ -32,14 +32,14 @@ namespace s3d
 
 	template <detail::ExitFunction ExitFunction>
 	template <class Fty>
-		requires detail::not_same_as<std::remove_cvref_t<Fty>, ScopeExit<ExitFunction>>
 	constexpr ScopeExit<ExitFunction>::ScopeExit(Fty&& exitFunction) noexcept(std::is_nothrow_constructible_v<ExitFunction, Fty&>)
+		requires detail::not_same_as<std::remove_cvref_t<Fty>, ScopeExit>
 		: m_exitFunction{ exitFunction } {}
 
 	template <detail::ExitFunction ExitFunction>
 	template <class Fty>
-		requires (detail::not_same_as<std::remove_cvref_t<Fty>, ScopeExit<ExitFunction>> && (not std::is_lvalue_reference_v<Fty>) && std::is_nothrow_constructible_v<ExitFunction, Fty>)
 	constexpr ScopeExit<ExitFunction>::ScopeExit(Fty&& exitFunction) noexcept
+		requires (detail::not_same_as<std::remove_cvref_t<Fty>, ScopeExit> && (not std::is_lvalue_reference_v<Fty>) && std::is_nothrow_constructible_v<ExitFunction, Fty>)
 		: m_exitFunction{ std::forward<Fty>(exitFunction) } {}
 
 	////////////////////////////////////////////////////////////////

--- a/Siv3D/include/Siv3D/detail/ScopeExit.ipp
+++ b/Siv3D/include/Siv3D/detail/ScopeExit.ipp
@@ -29,7 +29,7 @@ namespace s3d
 	template <class Fty>
 	constexpr ScopeExit<ExitFunction>::ScopeExit(Fty&& exitFunction) noexcept(std::is_nothrow_constructible_v<ExitFunction, Fty>
 																				|| std::is_nothrow_constructible_v<ExitFunction, Fty&>)
-		: m_exitFunction{ std::forward<ExitFunction>(exitFunction) } {}
+		: m_exitFunction{ std::forward<Fty>(exitFunction) } {}
 		
 	////////////////////////////////////////////////////////////////
 	//

--- a/Siv3D/include/Siv3D/detail/ScopeExit.ipp
+++ b/Siv3D/include/Siv3D/detail/ScopeExit.ipp
@@ -27,6 +27,7 @@ namespace s3d
 	
 	template <detail::ExitFunction ExitFunction>
 	template <class Fty>
+		requires detail::not_same_as<std::remove_cvref_t<Fty>, ScopeExit<ExitFunction>>
 	constexpr ScopeExit<ExitFunction>::ScopeExit(Fty&& exitFunction) noexcept(std::is_nothrow_constructible_v<ExitFunction, Fty>
 																				|| std::is_nothrow_constructible_v<ExitFunction, Fty&>)
 		: m_exitFunction{ std::forward<Fty>(exitFunction) } {}

--- a/Siv3D/include/Siv3D/detail/ScopeExit.ipp
+++ b/Siv3D/include/Siv3D/detail/ScopeExit.ipp
@@ -19,13 +19,13 @@ namespace s3d
 	//
 	////////////////////////////////////////////////////////////////
 
-	template <std::invocable ExitFunction>
+	template <detail::ExitFunction ExitFunction>
 	constexpr ScopeExit<ExitFunction>::ScopeExit(ScopeExit&& other) noexcept(std::is_nothrow_move_constructible_v<ExitFunction>
 																				|| std::is_nothrow_copy_constructible_v<ExitFunction>)
 		: m_exitFunction{ std::move(other.m_exitFunction) }
 		, m_active{ std::exchange(other.m_active, false) } {}
 	
-	template <std::invocable ExitFunction>
+	template <detail::ExitFunction ExitFunction>
 	template <class Fty>
 	constexpr ScopeExit<ExitFunction>::ScopeExit(Fty&& exitFunction) noexcept(std::is_nothrow_constructible_v<ExitFunction, Fty>
 																				|| std::is_nothrow_constructible_v<ExitFunction, Fty&>)
@@ -37,8 +37,8 @@ namespace s3d
 	//
 	////////////////////////////////////////////////////////////////
 
-	template <std::invocable ExitFunction>
-	constexpr ScopeExit<ExitFunction>::~ScopeExit() noexcept(std::is_nothrow_invocable_v<ExitFunction>
+	template <detail::ExitFunction ExitFunction>
+	constexpr ScopeExit<ExitFunction>::~ScopeExit() noexcept(std::is_nothrow_invocable_v<ExitFunction&>
 		&& std::is_nothrow_destructible_v<ExitFunction>)
 	{
 		if (m_active)
@@ -53,7 +53,7 @@ namespace s3d
 	//
 	////////////////////////////////////////////////////////////////
 
-	template <std::invocable ExitFunction>
+	template <detail::ExitFunction ExitFunction>
 	constexpr void ScopeExit<ExitFunction>::release() noexcept
 	{
 		m_active = false;

--- a/Siv3D/include/Siv3D/detail/ScopeExit.ipp
+++ b/Siv3D/include/Siv3D/detail/ScopeExit.ipp
@@ -12,7 +12,7 @@
 # pragma once
 
 namespace s3d
-{		
+{
 	////////////////////////////////////////////////////////////////
 	//
 	//	(constructor)
@@ -20,18 +20,28 @@ namespace s3d
 	////////////////////////////////////////////////////////////////
 
 	template <detail::ExitFunction ExitFunction>
-	constexpr ScopeExit<ExitFunction>::ScopeExit(ScopeExit&& other) noexcept(std::is_nothrow_move_constructible_v<ExitFunction>
-																				|| std::is_nothrow_copy_constructible_v<ExitFunction>)
-		: m_exitFunction{ std::move(other.m_exitFunction) }
+	constexpr ScopeExit<ExitFunction>::ScopeExit(ScopeExit&& other) noexcept(std::is_nothrow_copy_constructible_v<ExitFunction>)
+		: m_exitFunction{ other.m_exitFunction }
 		, m_active{ std::exchange(other.m_active, false) } {}
-	
+
+	template <detail::ExitFunction ExitFunction>
+	constexpr ScopeExit<ExitFunction>::ScopeExit(ScopeExit&& other) noexcept
+		requires std::is_nothrow_move_constructible_v<ExitFunction>
+		: m_exitFunction{ std::forward<ExitFunction>(other.m_exitFunction) }
+		, m_active{ std::exchange(other.m_active, false) } {}
+
 	template <detail::ExitFunction ExitFunction>
 	template <class Fty>
 		requires detail::not_same_as<std::remove_cvref_t<Fty>, ScopeExit<ExitFunction>>
-	constexpr ScopeExit<ExitFunction>::ScopeExit(Fty&& exitFunction) noexcept(std::is_nothrow_constructible_v<ExitFunction, Fty>
-																				|| std::is_nothrow_constructible_v<ExitFunction, Fty&>)
+	constexpr ScopeExit<ExitFunction>::ScopeExit(Fty&& exitFunction) noexcept(std::is_nothrow_constructible_v<ExitFunction, Fty&>)
+		: m_exitFunction{ exitFunction } {}
+
+	template <detail::ExitFunction ExitFunction>
+	template <class Fty>
+		requires (detail::not_same_as<std::remove_cvref_t<Fty>, ScopeExit<ExitFunction>> && (not std::is_lvalue_reference_v<Fty>) && std::is_nothrow_constructible_v<ExitFunction, Fty>)
+	constexpr ScopeExit<ExitFunction>::ScopeExit(Fty&& exitFunction) noexcept
 		: m_exitFunction{ std::forward<Fty>(exitFunction) } {}
-		
+
 	////////////////////////////////////////////////////////////////
 	//
 	//	(destructor)
@@ -47,7 +57,7 @@ namespace s3d
 			std::invoke(m_exitFunction);
 		}
 	}
-		
+
 	////////////////////////////////////////////////////////////////
 	//
 	//	release


### PR DESCRIPTION
#8 と同じ箇所の修正です。
MSVC と Clang でコンパイルエラーが発生する問題を修正しました。
