### PR TITLE
explicit narrowing

### DIFF
--- a/Siv3D/src/Siv3D-Platform/WindowsDesktop/Siv3D/Renderer/D3D11/BlendState/D3D11BlendState.cpp
+++ b/Siv3D/src/Siv3D-Platform/WindowsDesktop/Siv3D/Renderer/D3D11/BlendState/D3D11BlendState.cpp
@@ -81,7 +81,7 @@ namespace s3d
 					.SrcBlendAlpha			= static_cast<D3D11_BLEND>(state.sourceAlpha),
 					.DestBlendAlpha			= static_cast<D3D11_BLEND>(state.destinationAlpha),
 					.BlendOpAlpha			= static_cast<D3D11_BLEND_OP>(state.alphaOperation),
-					.RenderTargetWriteMask	= ((state.writeA << 3) | (state.writeB << 2) | (state.writeG << 1) | uint32(state.writeR)),
+					.RenderTargetWriteMask	= UINT8((state.writeA << 3) | (state.writeB << 2) | (state.writeG << 1) | uint32(state.writeR)),
 				}
 			}
 		};


### PR DESCRIPTION
C++11 forbids implicit narrowing in braced initialization