### PR TITLE
fallback implementation for container's range support

### DIFF
--- a/Siv3D/include/Siv3D/Array.hpp
+++ b/Siv3D/include/Siv3D/Array.hpp
@@ -10,8 +10,9 @@
 //-----------------------------------------------
 
 # pragma once
-# include <vector>
 # include <algorithm>
+# include <vector>
+# include <version>
 # include "String.hpp"
 # include "Unicode.hpp"
 # include "Format.hpp"
@@ -188,7 +189,7 @@ namespace s3d
 		[[nodiscard]]
 		constexpr Array(std::initializer_list<value_type> list, const Allocator& alloc = Allocator{});
 
-	# ifdef __cpp_lib_containers_ranges
+	# if __cpp_lib_containers_ranges >= 202202L
 		
 		/// @brief 範囲から配列を作成します。
 		/// @tparam Range 範囲の型
@@ -2074,8 +2075,8 @@ namespace s3d
 	Array(Iterator, Iterator, Allocator = Allocator{})
 		-> Array<typename std::iterator_traits<Iterator>::value_type, Allocator>;
 
-# ifdef __cpp_lib_containers_ranges
-	   
+# if __cpp_lib_containers_ranges >= 202202L
+	
 	template<std::ranges::input_range Range, class Allocator = std::allocator<std::ranges::range_value_t<Range>>>
 	Array(std::from_range_t, Range&&, Allocator = Allocator{})
 		-> Array<std::ranges::range_value_t<Range>, Allocator>;

--- a/Siv3D/include/Siv3D/Array.hpp
+++ b/Siv3D/include/Siv3D/Array.hpp
@@ -11,6 +11,7 @@
 
 # pragma once
 # include <algorithm>
+# include <ranges>
 # include <vector>
 # include <version>
 # include "String.hpp"

--- a/Siv3D/include/Siv3D/String.hpp
+++ b/Siv3D/include/Siv3D/String.hpp
@@ -10,9 +10,11 @@
 //-----------------------------------------------
 
 # pragma once
-# include <string>
-# include <span>
 # include <functional>
+# include <ranges>
+# include <span>
+# include <string>
+# include <version>
 # include "Concepts.hpp"
 # include "RangeConcepts.hpp"
 # include "StringView.hpp"

--- a/Siv3D/include/Siv3D/detail/Array.ipp
+++ b/Siv3D/include/Siv3D/detail/Array.ipp
@@ -189,7 +189,12 @@ namespace s3d
 	template <Concept::ContainerCompatibleRange<Type> Range>
 	constexpr Array<Type, Allocator>& Array<Type, Allocator>::assign_range(Range&& range)
 	{
+	# if __cpp_lib_containers_ranges >= 202202L
 		m_container.assign_range(std::forward<Range>(range));
+	# else
+		auto common_range = std::views::common(std::forward<Range>(range));
+		m_container.assign(common_range.begin(), common_range.end());
+	# endif
 		return *this;
 	}
 
@@ -668,7 +673,12 @@ namespace s3d
 	template <Concept::ContainerCompatibleRange<Type> Range>
 	constexpr void Array<Type, Allocator>::append_range(Range&& range)
 	{
+	# if __cpp_lib_containers_ranges >= 202202L
 		m_container.append_range(std::forward<Range>(range));
+	# else
+		auto common_range = std::views::common(std::forward<Range>(range));
+		m_container.insert(m_container.end(), common_range.begin(), common_range.end());
+	# endif
 	}
 
 	////////////////////////////////////////////////////////////////

--- a/Siv3D/include/Siv3D/detail/Array.ipp
+++ b/Siv3D/include/Siv3D/detail/Array.ipp
@@ -87,7 +87,7 @@ namespace s3d
 	constexpr Array<Type, Allocator>::Array(const std::initializer_list<value_type> list, const Allocator& alloc)
 		: m_container(list, alloc) {}
 
-# ifdef __cpp_lib_containers_ranges
+# if __cpp_lib_containers_ranges >= 202202L
 	   
 	template <class Type, class Allocator>
 	template <Concept::ContainerCompatibleRange<Type> Range>
@@ -1976,7 +1976,7 @@ namespace s3d
 	template <class Range, class Elem>
 	constexpr Array<Elem> ToArray(Range&& range) requires Concept::ContainerCompatibleRange<Range, Elem>
 	{
-	# ifdef __cpp_lib_containers_ranges
+	# if __cpp_lib_containers_ranges >= 202202L
 	   
 		return Array<Elem>(std::from_range, std::forward<Range>(range));
 	

--- a/Siv3D/include/Siv3D/detail/BoolArray.ipp
+++ b/Siv3D/include/Siv3D/detail/BoolArray.ipp
@@ -453,7 +453,12 @@ namespace s3d
 		template <Concept::ContainerCompatibleRange<bool> Range>
 		constexpr Array& assign_range(Range&& range) SIV3D_LIFETIMEBOUND
 		{
+		# if __cpp_lib_containers_ranges >= 202202L
 			m_container.assign_range(std::forward<Range>(range));
+		# else
+			auto common_range = std::views::common(std::forward<Range>(range));
+			m_container.assign(common_range.begin(), common_range.end());
+		# endif
 			return *this;
 		}
 
@@ -1025,7 +1030,12 @@ namespace s3d
 		template <Concept::ContainerCompatibleRange<bool> Range>
 		constexpr void append_range(Range&& range)
 		{
+		# if __cpp_lib_containers_ranges >= 202202L
 			m_container.append_range(std::forward<Range>(range));
+		# else
+			auto common_range = std::views::common(std::forward<Range>(range));
+			m_container.insert(m_container.end(), common_range.begin(), common_range.end());
+		# endif
 		}
 
 		////////////////////////////////////////////////////////////////

--- a/Siv3D/include/Siv3D/detail/BoolArray.ipp
+++ b/Siv3D/include/Siv3D/detail/BoolArray.ipp
@@ -307,7 +307,7 @@ namespace s3d
 		constexpr Array(std::initializer_list<value_type> list, const Allocator& alloc = Allocator{})
 			: m_container(list, alloc) {}
 
-	# ifdef __cpp_lib_containers_ranges
+	# if __cpp_lib_containers_ranges >= 202202L
 
 		/// @brief 範囲から配列を作成します。
 		/// @tparam Range 範囲の型

--- a/Siv3D/include/Siv3D/detail/String.ipp
+++ b/Siv3D/include/Siv3D/detail/String.ipp
@@ -69,7 +69,7 @@ namespace s3d
 	constexpr String::String(const StringViewLike auto& s, const size_type pos, const size_type count)
 		: m_string(s, pos, count) {}
 
-# ifdef __cpp_lib_containers_ranges
+# if __cpp_lib_containers_ranges >= 202202L
 
 	template <class Range> requires Concept::ContainerCompatibleRange<String::value_type, Range>
 	constexpr String::String(std::from_range_t, Range&& range)
@@ -219,13 +219,14 @@ namespace s3d
 	template <class Range> requires Concept::ContainerCompatibleRange<String::value_type, Range>
 	constexpr String& String::assign_range(Range&& range)
 	{
-	# ifdef __cpp_lib_containers_ranges
+	# if __cpp_lib_containers_ranges >= 202202L
 		
 		m_string.assign_range(std::forward<Range>(range));
 
 	# else
-		
-		m_string.assign(range.begin(), range.end());
+
+		auto common_range = std::views::common(std::forward<Range>(range));
+		m_string.assign(common_range.begin(), common_range.end());
 		
 	# endif
 
@@ -713,13 +714,14 @@ namespace s3d
 	template <class Range> requires Concept::ContainerCompatibleRange<String::value_type, Range>
 	constexpr String::iterator String::insert_range(const_iterator pos, Range&& range)
 	{
-	# ifdef __cpp_lib_containers_ranges
+	# if __cpp_lib_containers_ranges >= 202202L
 		
 		return m_string.insert_range(pos, std::forward<Range>(range));
 		
 	# else
-	
-		return m_string.insert(pos, range.begin(), range.end());
+
+		auto common_range = std::views::common(std::forward<Range>(range));
+		return m_string.insert(pos, common_range.begin(), common_range.end());
 		
 	# endif
 	}
@@ -906,13 +908,14 @@ namespace s3d
 	template <class Range> requires Concept::ContainerCompatibleRange<String::value_type, Range>
 	constexpr String& String::append_range(Range&& range)
 	{
-	# ifdef __cpp_lib_containers_ranges
+	# if __cpp_lib_containers_ranges >= 202202L
 	
 		m_string.append_range(std::forward<Range>(range));
 	
 	# else
-		
-		m_string.append(range.begin(), range.end());
+
+		auto common_range = std::views::common(std::forward<Range>(range));
+		m_string.append(common_range.begin(), common_range.end());
 		
 	# endif
 		


### PR DESCRIPTION
This adds fallback implementations to `assign_range` and `append_range` in `Array` since `String` has them.
Also, the argument should be wrapped by `common_view` for pre-C++20 interface.