### PR TITLE
fix typo

### DIFF
--- a/Siv3D/include/Siv3D/String.hpp
+++ b/Siv3D/include/Siv3D/String.hpp
@@ -801,11 +801,11 @@ namespace s3d
 
 		constexpr String& replace(size_type pos, size_type count, const String& s) SIV3D_LIFETIMEBOUND;
 
-		constexpr String& replate(const_iterator first, const_iterator last, const String& s) SIV3D_LIFETIMEBOUND;
+		constexpr String& replace(const_iterator first, const_iterator last, const String& s) SIV3D_LIFETIMEBOUND;
 		
 		constexpr String& replace(const_iterator first, const_iterator last, const value_type* s) SIV3D_LIFETIMEBOUND;
 
-		constexpr String& replate(const_iterator first, const_iterator last, const StringViewLike auto& s);
+		constexpr String& replace(const_iterator first, const_iterator last, const StringViewLike auto& s);
 
 		constexpr String& replace(size_type pos, size_type count, const value_type* s) SIV3D_LIFETIMEBOUND;
 

--- a/Siv3D/include/Siv3D/detail/String.ipp
+++ b/Siv3D/include/Siv3D/detail/String.ipp
@@ -973,7 +973,7 @@ namespace s3d
 		return *this;
 	}
 
-	constexpr String& String::replate(const_iterator first, const_iterator last, const String& s)
+	constexpr String& String::replace(const_iterator first, const_iterator last, const String& s)
 	{
 		m_string.replace(first, last, s.m_string);
 		return *this;
@@ -985,7 +985,7 @@ namespace s3d
 		return *this;
 	}
 
-	constexpr String& String::replate(const_iterator first, const_iterator last, const StringViewLike auto& s)
+	constexpr String& String::replace(const_iterator first, const_iterator last, const StringViewLike auto& s)
 	{
 		m_string.replace(first, last, s);
 		return *this;


### PR DESCRIPTION
some of `replace` overloads are accidentally named as `replate`.