### PR TITLE
Polygon::drawFrame() のバグを修正

### DIFF
--- a/Siv3D/src/Siv3D/Polygon/PolygonDetail.cpp
+++ b/Siv3D/src/Siv3D/Polygon/PolygonDetail.cpp
@@ -814,7 +814,7 @@ namespace s3d
 		for (const auto& hole : m_polygon.inners())
 		{
 			SIV3D_ENGINE(Renderer2D)->addLineString(LineCap::Square, LineCap::Square,
-				m_polygon.outer(), offset,
+				hole, offset,
 				Abs(static_cast<float>(thickness)), false,
 				CloseRing::Yes,
 				color.toFloat4());
@@ -837,7 +837,7 @@ namespace s3d
 		for (const auto& hole : m_polygon.inners())
 		{
 			SIV3D_ENGINE(Renderer2D)->addLineString(LineCap::Square, LineCap::Square,
-				m_polygon.outer(), offset,
+				hole, offset,
 				Abs(static_cast<float>(thickness)), false,
 				CloseRing::Yes,
 				pattern);

--- a/Siv3D/src/Siv3D/Renderer2D/Vertex2DBuilder_Rounded.cpp
+++ b/Siv3D/src/Siv3D/Renderer2D/Vertex2DBuilder_Rounded.cpp
@@ -1257,17 +1257,6 @@ namespace s3d
 				pVertex[newSize * 2 - 1].pos.set(result1);
 			}
 
-			if (offset)
-			{
-				const Float2 v = *offset;
-				Vertex2D* pDst = pVertex;
-
-				for (Vertex2D::IndexType i = 0; i < vertexSize; ++i)
-				{
-					(pDst++)->pos.moveBy(v);
-				}
-			}
-
 			for (size_t i = 0; i < vertexSize; ++i)
 			{
 				(pVertex++)->color = color;
@@ -1364,17 +1353,6 @@ namespace s3d
 				const Float4& color = cBuf[newSize - 1];
 				pVertex[newSize * 2 - 2].set(result0, color);
 				pVertex[newSize * 2 - 1].set(result1, color);
-			}
-
-			if (offset)
-			{
-				const Float2 v = *offset;
-				Vertex2D* pDst = pVertex;
-
-				for (Vertex2D::IndexType i = 0; i < vertexSize; ++i)
-				{
-					(pDst++)->pos.moveBy(v);
-				}
 			}
 
 			{


### PR DESCRIPTION
- `Polygon::drawFrame()` で穴が描画されないバグを修正しました
- `Polygon::drawFrame()` で使用される `BuildClosedLineString()` で `offset` が各頂点の座標に2回足されることで `offset` の2倍を足した位置に描画されるバグを修正しました
  - `BuildClosedLineString()` 本体と `SimplifyClosed()` でそれぞれ `offset` が足されていたので、 `BuildClosedLineString()` 本体の方を削除しました

```cpp
# include <Siv3D.hpp> // Siv3D v0.8.0

void Main()
{
	Scene::SetBackground(ColorF{ 0.6, 0.8, 0.7 });

	while (System::Update())
	{
		const double t = Scene::Time();

		Polygon polygon = Rect{ -100, -100, 200, 200 }.asPolygon();
		polygon.addHole(Triangle{ 100, (t * 3) });

		polygon.draw(200, 300);

		polygon.drawFrame(600, 300, 2);
	}
}
```

**修正前（描画位置は調整しています）**
![20241128-132638-274](https://github.com/user-attachments/assets/d045a3de-da47-471f-a67b-64e8bf260613)

**修正後**
![20241128-132510-740](https://github.com/user-attachments/assets/57d0e380-1cbb-476c-a053-050e0e2a9d99)

